### PR TITLE
Tune README.md for copy/paste templates and typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Add modules to modules/extensions/pom.xml
 Add extension to the list of managed extensions at the end of workspace-config/extensions/managed-extensions.txt:
 
 ```
-echo "connectors" >> workspace-config/extensions/managed-extensions.txt
+echo "connectors" >> workspace-configuration/extensions/managed-extensions.txt
 ```
 
 Download the extension tool:
@@ -44,7 +44,7 @@ mvn dependency:copy -Dartifact=com.coremedia.tools.extensions:extensions:LATEST:
 Execute the extension tool:
 
 ```
-java -jar extensions-tool/extensions.jar --task synchronize --extension-config-file  workspace-config/extensions/extension-config.properties --task-input-file workspace-config/extensions/managed-extensions.txt
+java -jar tool/extensions.jar --task synchronize --extension-config-file  workspace-configuration/extensions/extension-config.properties --task-input-file workspace-configuration/extensions/managed-extensions.txt
 ```
 
 For the IDEA import:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # CoreMedia Studio Hub
 
 
-The CoreMedia Studio Hub allows to integrate various external
-and asset management systems into the Studio library and to preview items of these systems.
-It allows you to integrate just about any external system or platform into your CoreMedia system.
-The Studio Hub is implemented as a Blueprint extension.
+The CoreMedia Studio Hub allows to integrate various external and asset 
+management systems into the Studio library and to preview items of these 
+systems. It allows you to integrate just about any external system or platform 
+into your CoreMedia system. The Studio Hub is implemented as a Blueprint 
+extension.
 
 ### Documentation & Tutorial
 
@@ -16,21 +17,36 @@ https://github.com/CoreMedia/coremedia-studio-hub/issues
 
 ### Installation
 
-Add our submodules to the extensions folder (cd modules/extensions): 
+Add our submodules to the extensions folder
 
-    git submodule add https://github.com/CoreMedia/coremedia-studio-hub.git
+```
+git submodule add https://github.com/CoreMedia/coremedia-studio-hub.git modules/extensions/connectors
+```
 
 Add modules to modules/extensions/pom.xml
 
-```<module>coremedia-feedback-hub</module>```
+```
+<module>connectors</module>
+```
+
+Add extension to the list of managed extensions at the end of workspace-config/extensions/managed-extensions.txt:
+
+```
+echo "connectors" >> workspace-config/extensions/managed-extensions.txt
+```
+
+Download the extension tool:
+
+```
+mvn dependency:copy -Dartifact=com.coremedia.tools.extensions:extensions:LATEST:jar:all -DlocalRepositoryDirectory=extensions-tool -Dtransitive=false -DoutputDirectory=tool -Dmdep.stripVersion=true -Dmdep.stripClassifier=true
+```
 
 Execute the extension tool:
 
-- workspace-config/extensions execute: mvn dependency:copy -Dartifact=com.coremedia.tools.extensions:extensions:LATEST:jar:all -DlocalRepositoryDirectory=extensions-tool -Dtransitive=false -DoutputDirectory=tool -Dmdep.stripVersion=true -Dmdep.stripClassifier=true
-- workspace-config/extensions, execute: java -jar tool/extensions.jar --task synchronize --extension-config-file  extension-config.properties --task-input-file managed-extensions.txt
+```
+java -jar extensions-tool/extensions.jar --task synchronize --extension-config-file  workspace-config/extensions/extension-config.properties --task-input-file workspace-config/extensions/managed-extensions.txt
+```
 
 For the IDEA import:
 - Ignore folder ".remote-package"
 - Disable "Settings > Compiler > Clear output directory on rebuild"
-
-


### PR DESCRIPTION
The generic command line notes in the readme are now valid copy/paste patterns. Also some typos - if I got it right - have been fixed.